### PR TITLE
グループ作成機能の実装

### DIFF
--- a/app/assets/stylesheets/_common.scss
+++ b/app/assets/stylesheets/_common.scss
@@ -27,6 +27,7 @@
     height: calc(100vh - 100px);
     background-color: #2f3e51;
     padding: 0 20px;
+    overflow: scroll;
     .chat-group {
       padding: 20px 0;
       &__name {

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -1,13 +1,28 @@
 class GroupsController < ApplicationController
-  def create
+  def new
+    @group = Group.new
   end
 
-  def new
+  def create
+    #groupとuser_idsで関連付いたuserを合わせて作成
+    @group = Group.new(create_params)
+    if @group.save
+      redirect_to root_path, notice: 'グループを作成しました'
+    else
+      render :new
+    end
   end
 
   def edit
   end
 
   def update
+  end
+
+  private
+
+  #formで送られてきたパラメーターをストロングパラメータとして取得
+  def create_params
+    params.require(:group).permit(:name, { :user_ids => [] })
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,7 +4,6 @@ class UsersController < ApplicationController
   end
 
   def update
-    
     if current_user.update(user_params)
       redirect_to controller: 'messages', action: 'index'
     else
@@ -13,7 +12,7 @@ class UsersController < ApplicationController
   end
 
   private
-  
+
   def user_params
     params.require(:user).permit(:name, :email)
   end

--- a/app/views/groups/new.html.haml
+++ b/app/views/groups/new.html.haml
@@ -1,16 +1,17 @@
 .chat-group-form
   %h1 新規チャットグループ
-  %form#new_chat_group.new_chat_group{"accept-charset" => "UTF-8", action: "/chat_groups", method: "post"}
-    .chat-group-form__errors
-      %h2
-        1件のエラーが発生しました。
+  = form_for @group, id: 'new_chat_group', class:'new_chat_group' do |f|
+    - if @group.errors.any?
+      .chat-group-form__errors
+        %h2= "#{@group.errors.count}件のエラーが発生しました。"
         %ul
-          %li エラーです
+          - @group.errors.full_messages.each do |message|
+            %li= message
     .chat-group-form__field.clearfix
       .chat-group-form__field--left
-        %label.chat-group-form__label{for: "chat_group_name"} グループ名
+        = f.label "グループ名", class: 'chat-group-form__label'
       .chat-group-form__field--right
-        %input#chat_group_name.chat-group-form__input{name: "chat_group[name]", placeholder: "グループ名を入力してください", type: "text"}/
+        = f.text_field :name, id: 'chat_group_name', class: 'chat-group-form__input', placeholder: "グループ名を入力してください", type: "text"
     .chat-group-form__field.clearfix
       / この部分はインクリメンタルサーチ（ユーザー追加の非同期化のときに使用します
       /
@@ -28,6 +29,8 @@
         %label.chat-group-form__label{for: "chat_group_チャットメンバー"} チャットメンバー
       .chat-group-form__field--right
         / グループ作成機能の追加時はここにcollection_check_boxesの記述を入れてください
+        = f.collection_check_boxes(:user_ids, User.all, :id, :name) do |user|
+          = user.label { user.check_box + user.text }
         / この部分はインクリメンタルサーチ（ユーザー追加の非同期化のときに使用します
         /
           <div id='chat-group-users'>
@@ -39,4 +42,4 @@
     .chat-group-form__field.clearfix
       .chat-group-form__field--left
       .chat-group-form__field--right
-        %input.chat-group-form__action-btn{"data-disable-with" => "Save", name: "commit", type: "submit", value: "Save"}/
+        = f.submit class: "chat-group-form__action-btn", "data-disable-with" => "Save", name: "commit", value: "Save"

--- a/app/views/layouts/messages.html.haml
+++ b/app/views/layouts/messages.html.haml
@@ -8,26 +8,5 @@
     = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
   %body
     = render 'layouts/flash_messages'
-    .left-sidebar
-      .sidebar-header
-        %h3.sidebar-header__user
-          = current_user.name
-        .sidebar-header__btns
-          = link_to new_group_path, class: "sidebar-header--btn" do
-            %span<>
-              = fa_icon 'edit'
-          = link_to edit_user_path(current_user.id), method: :get, class: "sidebar-header--btn" do
-            %span<>
-              = fa_icon 'cog'
-      .sidebar-contents
-        .chat-group
-          .chat-group__name
-            グループ名1
-          .chat-group__message
-            初回メッセージ1
-        .chat-group
-          .chat-group__name
-            グループ名2
-          .chat-group__message
-            初回メッセージ2
+    = render 'shared/side_bar'
     = yield

--- a/app/views/shared/_side_bar.html.haml
+++ b/app/views/shared/_side_bar.html.haml
@@ -1,0 +1,18 @@
+.left-sidebar
+  .sidebar-header
+    %h3.sidebar-header__user
+      = current_user.name
+    .sidebar-header__btns
+      = link_to new_group_path, class: "sidebar-header--btn" do
+        %span<>
+          = fa_icon 'edit'
+      = link_to edit_user_path(current_user.id), method: :get, class: "sidebar-header--btn" do
+        %span<>
+          = fa_icon 'cog'
+  .sidebar-contents
+    - current_user.groups.each do |group|
+      .chat-group
+        .chat-group__name
+          = group.name
+        .chat-group__message
+          初回メッセージ1


### PR DESCRIPTION
# WHAT
チャットグループの管理画面のユーザー作成機能を実装し、
Railsアプリケーションでグループを扱えるようにする。

# WHY
グループを作成するため。

# やること

1. グループ作成機能を実装する(collection_check_boxesを使用する）
2. グループ作成成功時はフラッシュメッセージを表示させる
3. グループ名にバリデーションをかけグループの保存失敗時にエラーメッセージを表示する
4. グループ一覧をサイドバーに表示する