### PR TITLE
投稿機能の非同期機能の作成

### DIFF
--- a/app/assets/javascripts/messages.js
+++ b/app/assets/javascripts/messages.js
@@ -49,6 +49,12 @@ $(function() {
       $(".chat--messages").append(html);
     }
   }
+
+  //jqueryで無効化したSendボタンの有効化
+  function send_button_enable() {
+    $('#form--send-button').prop('disabled', false);
+  }
+
   $(".new_message").on("submit", function(e) {
     e.preventDefault();
     var formData = new FormData(this);
@@ -73,13 +79,13 @@ $(function() {
         { duration: 2000 }
       );
       //Sendボタンの有効化
-      $('#form--send-button').prop('disabled', false);
+      send_button_enable();
     })
     .fail(function()
     {
       alert("エラー");
       //Sendボタンの有効化
-      $('#form--send-button').prop('disabled', false);
+      send_button_enable();
     });
   });
 })

--- a/app/assets/javascripts/messages.js
+++ b/app/assets/javascripts/messages.js
@@ -3,7 +3,7 @@ $(function() {
   function buildMessage(message)
   {
     var html = null;
-    if(message.body && message.image)
+    if(message.body && message.image.url)
     {
       html = `<div class="message">
                 <div class="message--title">
@@ -48,7 +48,6 @@ $(function() {
       // 作成したHTMLをメッセージ画面の一番下に追加する
       $(".chat--messages").append(html);
     }
-
   }
   $(".new_message").on("submit", function(e) {
     e.preventDefault();
@@ -63,7 +62,13 @@ $(function() {
       contentType: false
     })
     .done(function(message) {
+      //HTML要素を作成して追加
       buildMessage(message);
+      //スクロール
+      $(".chat--messages").animate(
+        { scrollTop:$(".message").last().offset().top },
+        { duration: 2000 }
+      );
     })
     .fail(function()
     {

--- a/app/assets/javascripts/messages.js
+++ b/app/assets/javascripts/messages.js
@@ -64,15 +64,20 @@ $(function() {
     .done(function(message) {
       //HTML要素を作成して追加
       buildMessage(message);
+      $("#form--text-input").val("");
       //スクロール
       $(".chat--messages").animate(
         { scrollTop:$(".message").last().offset().top },
         { duration: 2000 }
       );
+      //Sendボタンの有効化
+      $('#form--send-button').prop('disabled', false);
     })
     .fail(function()
     {
       alert("エラー");
+      //Sendボタンの有効化
+      $('#form--send-button').prop('disabled', false);
     });
   });
 })

--- a/app/assets/javascripts/messages.js
+++ b/app/assets/javascripts/messages.js
@@ -65,9 +65,11 @@ $(function() {
       //HTML要素を作成して追加
       buildMessage(message);
       $("#form--text-input").val("");
-      //スクロール
+      //現在位置+最終コメント要素の相対位置にスクロール
+      var currentScrollTop = $(".chat--messages").scrollTop()
+      var scrollSize = $(".message").last().offset().top
       $(".chat--messages").animate(
-        { scrollTop:$(".message").last().offset().top },
+        { scrollTop: currentScrollTop + scrollSize },
         { duration: 2000 }
       );
       //Sendボタンの有効化

--- a/app/assets/javascripts/messages.js
+++ b/app/assets/javascripts/messages.js
@@ -1,4 +1,55 @@
 $(function() {
+  // 個々のmessageを表示するHTMLを作成
+  function buildMessage(message)
+  {
+    var html = null;
+    if(message.body && message.image)
+    {
+      html = `<div class="message">
+                <div class="message--title">
+                  <span class="message--title__post-user">${message.user_name}</span>
+                  <span class="message--title__post-date">${message.create_date}</span>
+                  <div class="message--text">
+                    ${message.body}
+                  </div>
+                  <div class="message--image">
+                    <img src="${message.image.url}">
+                  </div>
+                </div>
+              </div>`;
+    }
+    else if(message.body)
+    {
+      html = `<div class="message">
+                <div class="message--title">
+                  <span class="message--title__post-user">${message.user_name}</span>
+                  <span class="message--title__post-date">${message.create_date}</span>
+                  <div class="message--text">
+                    ${message.body}
+                  </div>
+                </div>
+              </div>`;
+    }
+    else if(message.image)
+    {
+      html = `<div class="message">
+                <div class="message--title">
+                  <span class="message--title__post-user">${message.user_name}</span>
+                  <span class="message--title__post-date">${message.create_date}</span>
+                  <div class="message--image">
+                    <img src="${message.image.url}">
+                  </div>
+                </div>
+              </div>`;
+    }
+
+    if(html)
+    {
+      // 作成したHTMLをメッセージ画面の一番下に追加する
+      $(".chat--messages").append(html);
+    }
+
+  }
   $(".new_message").on("submit", function(e) {
     e.preventDefault();
     var formData = new FormData(this);
@@ -10,6 +61,13 @@ $(function() {
       dataType: "json",
       processData: false,
       contentType: false
+    })
+    .done(function(message) {
+      buildMessage(message);
+    })
+    .fail(function()
+    {
+      alert("エラー");
     });
   });
 })

--- a/app/assets/javascripts/messages.js
+++ b/app/assets/javascripts/messages.js
@@ -1,0 +1,15 @@
+$(function() {
+  $(".new_message").on("submit", function(e) {
+    e.preventDefault();
+    var formData = new FormData(this);
+    var url = $(this).attr("action");
+    $.ajax({
+      type: "POST",
+      url: url,
+      data: formData,
+      dataType: "json",
+      processData: false,
+      contentType: false
+    });
+  });
+})

--- a/app/assets/javascripts/messages.js
+++ b/app/assets/javascripts/messages.js
@@ -30,7 +30,7 @@ $(function() {
                 </div>
               </div>`;
     }
-    else if(message.image)
+    else if(message.image.url)
     {
       html = `<div class="message">
                 <div class="message--title">

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -9,18 +9,31 @@ class MessagesController < ApplicationController
     @message = @group.messages.new(message_param)
     # バリデーション
     unless @message.valid?
-      flash.now[:alert] = "メッセージを入力してください。"
-      render :index
+      respond_to do |format|
+        format.html {
+          flash.now[:alert] = "メッセージを入力してください"
+          render :index
+        }
+        format.json { }
+      end
       return
     end
 
     #メッセージ保存（送信）
     if @message.save
-      redirect_to group_messages_path(@group), notice: "メッセージを送信しました"
+      respond_to do |format|
+        format.html { redirect_to group_messages_path(@group), notice: "メッセージを送信しました"}
+        format.json { }
+      end
     else
       @messages = @group.messages.includes(:user)
-      flash.now[:alert] = "メッセージを送信できませんでした。"
-      render :index
+      respond_to do |format|
+        format.html {
+          flash.now[:alert] = "メッセージ送信エラー"
+          render :index
+        }
+        format.json { }
+      end
     end
   end
 

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,4 +1,4 @@
 json.body @message.body
 json.image @message.image
 json.user_name @message.user.name
-json.create_date @message.created_at
+json.create_date @message.created_at.strftime("%Y/%m/%d(%a) %H:%M:%S")

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,0 +1,4 @@
+json.body @message.body
+json.image @message.image
+json.user_name @message.user.name
+json.create_date @message.created_at

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -19,7 +19,7 @@ Rails.application.configure do
   config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
 
   # Compress JavaScripts and CSS.
-  config.assets.js_compressor = :uglifier
+  # config.assets.js_compressor = :uglifier
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.


### PR DESCRIPTION
# What
Chatspaceに投稿機能の非同期機能を追加する。

# Why
メッセージ送信を行った時にページがリダイレクトしてしまうのを、
非同期通信を使うことでリダイレクト無しで行えるようにする。

# 実装ステップ
1.  jsファイルを作成する
2. フォームが送信されたら、イベントが発火するようにする
3. イベントが発火したときにAjaxを使用して、messages#createが動くようにする
4. messages#createでメッセージを保存し、respond_toを使用してHTMLとJSONの場合で処理を分ける
5. jbuilderを使用して、作成したメッセージをJSON形式で返す
6. 返ってきたJSONをdoneメソッドで受取り、HTMLを作成する
7. 作成したHTMLをメッセージ画面の一番下に追加する
8. HTMLを追加した分、メッセージ画面を下にスクロールする
9. 連続で送信ボタンを押せるようにする
10. 非同期に失敗した場合の処理も準備する