### PR TITLE
ユーザーのインクリメンタルサーチの実装

### DIFF
--- a/app/assets/javascripts/users_search.js
+++ b/app/assets/javascripts/users_search.js
@@ -1,0 +1,44 @@
+$(function() {
+
+  var search_list = $(".user-search-result");
+
+  function buildSearchUser(user) {
+    var html = `<div class="chat-group-user clearfix">
+                  <p class="chat-group-user__name">${user.name}</p>
+                  <div class="user-search-add chat-group-user__btn chat-group-user__btn--add" data-user-id="ユーザーのid" data-user-name="ユーザー名">追加</div>
+                </div>`
+    search_list.append(html);
+  }
+
+  function appendSearchErrMsgToHTML(msg) {
+    var html = `<div class="chat-group-user clearfix">
+                  <p class="chat-group-user__name">${msg}</p>
+                </div>`
+    search_list.append(html);
+  }
+
+  $("#user-search-field").on("keyup", function() {
+    var input = $("#user-search-field").val();
+
+    $.ajax({
+      type: "get",
+      url: "/users",
+      data: { keyword: input },
+      dataType: "json"
+    })
+    .done(function(users) {
+      search_list.empty();
+      if (users.length !== 0) {
+        users.forEach(function(user){
+          buildSearchUser(user);
+        });
+      }
+      else {
+        appendSearchErrMsgToHTML("一致するユーザーはありません");
+      }
+    })
+    .fail(function() {
+      alert('ユーザー検索に失敗しました');
+    });
+  });
+})

--- a/app/assets/javascripts/users_search.js
+++ b/app/assets/javascripts/users_search.js
@@ -17,10 +17,10 @@ $(function() {
 
   function buildGroupMenber(user)
   {
-    var html = `<div class='chat-group-user clearfix js-chat-member' id='chat-group-user-8'>
-                  <input name='group[user_ids][]' type='hidden' value='${user.id}'>
-                  <p class='chat-group-user__name'>${user.name}</p>
-                  <div class='user-search-remove chat-group-user__btn chat-group-user__btn--remove js-remove-btn'>削除</div>
+    var html = `<div class="chat-group-user clearfix js-chat-member" id="chat-group-user-8">
+                  <input name="group[user_ids][]" type="hidden" value="${user.id}">
+                  <p class="chat-group-user__name">${user.name}</p>
+                  <div class="user-search-remove chat-group-user__btn chat-group-user__btn--remove js-remove-btn">削除</div>
                 </div>`
     $(".group-member").append(html);
   }
@@ -51,6 +51,7 @@ $(function() {
       });
     });
 
+    //追加ボタンをクリック
     $(".user-search-result").on("click",".chat-group-user__btn.chat-group-user__btn--add",function() {
       //追加ボタンの情報を取得
       var user = { "id" : $(this).attr("data-user-id"),
@@ -61,6 +62,7 @@ $(function() {
       $(this).parent().remove();
     });
 
+    //削除ボタンをクリック
     $(".group-member").on("click",".chat-group-user__btn.user-search-remove",function() {
       //クリックしたチャットメンバーをグループ一覧から消去
       $(this).parent().remove();

--- a/app/assets/javascripts/users_search.js
+++ b/app/assets/javascripts/users_search.js
@@ -1,44 +1,44 @@
 $(function() {
 
-  var search_list = $(".user-search-result");
-
   function buildSearchUser(user) {
     var html = `<div class="chat-group-user clearfix">
                   <p class="chat-group-user__name">${user.name}</p>
                   <div class="user-search-add chat-group-user__btn chat-group-user__btn--add" data-user-id="ユーザーのid" data-user-name="ユーザー名">追加</div>
                 </div>`
-    search_list.append(html);
+    $(".user-search-result").append(html);
   }
 
   function appendSearchErrMsgToHTML(msg) {
     var html = `<div class="chat-group-user clearfix">
                   <p class="chat-group-user__name">${msg}</p>
                 </div>`
-    search_list.append(html);
+    $(".user-search-result").append(html);
   }
 
-  $("#user-search-field").on("keyup", function() {
-    var input = $("#user-search-field").val();
+  $(document).on('turbolinks:load', function() {
+    $("#user-search-field").on("keyup", function() {
+      var input = $("#user-search-field").val();
 
-    $.ajax({
-      type: "get",
-      url: "/users",
-      data: { keyword: input },
-      dataType: "json"
-    })
-    .done(function(users) {
-      search_list.empty();
-      if (users.length !== 0) {
-        users.forEach(function(user){
-          buildSearchUser(user);
-        });
-      }
-      else {
-        appendSearchErrMsgToHTML("一致するユーザーはありません");
-      }
-    })
-    .fail(function() {
-      alert('ユーザー検索に失敗しました');
+      $.ajax({
+        type: "get",
+        url: "/users",
+        data: { keyword: input },
+        dataType: "json"
+      })
+      .done(function(users) {
+        $(".user-search-result").empty();
+        if (users.length !== 0) {
+          users.forEach(function(user){
+            buildSearchUser(user);
+          });
+        }
+        else {
+          appendSearchErrMsgToHTML("一致するユーザーはありません");
+        }
+      })
+      .fail(function() {
+        alert('ユーザー検索に失敗しました');
+      });
     });
   });
 })

--- a/app/assets/javascripts/users_search.js
+++ b/app/assets/javascripts/users_search.js
@@ -3,7 +3,7 @@ $(function() {
   function buildSearchUser(user) {
     var html = `<div class="chat-group-user clearfix">
                   <p class="chat-group-user__name">${user.name}</p>
-                  <div class="user-search-add chat-group-user__btn chat-group-user__btn--add" data-user-id="ユーザーのid" data-user-name="ユーザー名">追加</div>
+                  <div class="user-search-add chat-group-user__btn chat-group-user__btn--add" data-user-id="${user.id}" data-user-name="${user.name}">追加</div>
                 </div>`
     $(".user-search-result").append(html);
   }
@@ -13,6 +13,16 @@ $(function() {
                   <p class="chat-group-user__name">${msg}</p>
                 </div>`
     $(".user-search-result").append(html);
+  }
+
+  function buildGroupMenber(user)
+  {
+    var html = `<div class='chat-group-user clearfix js-chat-member' id='chat-group-user-8'>
+                  <input name='group[user_ids][]' type='hidden' value='${user.id}'>
+                  <p class='chat-group-user__name'>${user.name}</p>
+                  <div class='user-search-remove chat-group-user__btn chat-group-user__btn--remove js-remove-btn'>削除</div>
+                </div>`
+    $(".group-member").append(html);
   }
 
   $(document).on('turbolinks:load', function() {
@@ -37,8 +47,24 @@ $(function() {
         }
       })
       .fail(function() {
-        alert('ユーザー検索に失敗しました');
+        alert("ユーザー検索に失敗しました");
       });
     });
+
+    $(".user-search-result").on("click",".chat-group-user__btn.chat-group-user__btn--add",function() {
+      //追加ボタンの情報を取得
+      var user = { "id" : $(this).attr("data-user-id"),
+                   "name" : $(this).attr("data-user-name") };
+      //追加したデータをチャットメンバー一覧に追加
+      buildGroupMenber(user);
+      //クリックしたチャットメンバーを検索結果から消去
+      $(this).parent().remove();
+    });
+
+    $(".group-member").on("click",".chat-group-user__btn.user-search-remove",function() {
+      //クリックしたチャットメンバーをグループ一覧から消去
+      $(this).parent().remove();
+    });
+
   });
 })

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,13 @@
 class UsersController < ApplicationController
 
+  def index
+    # 検索フォームのキーワードでユーザーを検索
+    @users = User.where('name LIKE(?)', "%#{params[:keyword]}%").order('id ASC').limit(20)
+    respond_to do |format|
+      format.json { }
+    end
+  end
+
   def edit
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,7 +2,9 @@ class UsersController < ApplicationController
 
   def index
     # 検索フォームのキーワードでユーザーを検索
-    @users = User.where('name LIKE(?)', "%#{params[:keyword]}%").order('id ASC').limit(20)
+    @users = User.where('name LIKE(?)', "%#{params[:keyword]}%")
+                 .where().not(id: current_user.id)
+                 .order('id ASC').limit(20)
     respond_to do |format|
       format.json { }
     end

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -26,12 +26,16 @@
         チャットメンバー
     .chat-group-form__field--right
       .group-member
+        %div{class: "chat-group-user clearfix js-chat-member", id: "chat-group-user-8"}
+          %input{ name: "group[user_ids][]", type: "hidden", value: current_user.id}
+          %p{class: "chat-group-user__name"}
+            = current_user.name
         - group.members.each do |member|
-          %div{class: "chat-group-user clearfix js-chat-member", id: "chat-group-user-8"}
-            %input{ name: "group[user_ids][]", type: "hidden", value: member.user.id}
-            %p{class: "chat-group-user__name"}
-              = member.user.name
-            - if current_user.id != member.user.id
+          - if current_user.id != member.user.id
+            %div{class: "chat-group-user clearfix js-chat-member", id: "chat-group-user-8"}
+              %input{ name: "group[user_ids][]", type: "hidden", value: member.user.id}
+              %p{class: "chat-group-user__name"}
+                = member.user.name
               %dic{class: "user-search-remove chat-group-user__btn chat-group-user__btn--remove js-remove-btn"}
                 削除
 

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -22,5 +22,12 @@
 
   .chat-group-form__field.clearfix
     .chat-group-form__field--left
+      %label.chat-group-form__label
+        チャットメンバー
+    .chat-group-form__field--right
+      .group-member
+
+  .chat-group-form__field.clearfix
+    .chat-group-form__field--left
     .chat-group-form__field--right
       = f.submit "Send", class: "chat-group-form__action-btn"

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -26,6 +26,14 @@
         チャットメンバー
     .chat-group-form__field--right
       .group-member
+        - group.members.each do |member|
+          %div{class: "chat-group-user clearfix js-chat-member", id: "chat-group-user-8"}
+            %input{ name: "group[user_ids][]", type: "hidden", value: member.user.id}
+            %p{class: "chat-group-user__name"}
+              = member.user.name
+            - if current_user.id != member.user.id
+              %dic{class: "user-search-remove chat-group-user__btn chat-group-user__btn--remove js-remove-btn"}
+                削除
 
   .chat-group-form__field.clearfix
     .chat-group-form__field--left

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -18,7 +18,7 @@
     .chat-group-form__field--right
       .chat-group-form__search.clearfix
         %input{class: "chat-group-form__input", id: "user-search-field", placeholder: "追加したいユーザー名を入力してください", type: "text"}
-    .user-search-result
+        .user-search-result
 
   .chat-group-form__field.clearfix
     .chat-group-form__field--left

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -10,7 +10,15 @@
       =f.label "グループ名", class: "chat-group-form__label"
     .chat-group-form__field--right
       = f.text_field :name, id: "chat_group_name", class: "chat-group-form__input", placeholder: "グループ名を入力してください", type: "text", value: group.name
+
   .chat-group-form__field.clearfix
+    .chat-group-form__field--left
+      %label.chat-group-form__label{for: "user-search-field"}
+        チャットメンバーを追加
+    .chat-group-form__field--right
+      .chat-group-form__search.clearfix
+        %input{class: "chat-group-form__input", id: "user-search-field", placeholder: "追加したいユーザー名を入力してください", type: "text"}
+    .user-search-result
     / この部分はインクリメンタルサーチ（ユーザー追加の非同期化のときに使用します
     /
       <div class='chat-group-form__field--left'>
@@ -22,6 +30,7 @@
       </div>
       <div id='user-search-result'></div>
       </div>
+
   .chat-group-form__field.clearfix
     .chat-group-form__field--left
       %label.chat-group-form__label{for: "chat_group_チャットメンバー"} チャットメンバー

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -19,25 +19,7 @@
       .chat-group-form__search.clearfix
         %input{class: "chat-group-form__input", id: "user-search-field", placeholder: "追加したいユーザー名を入力してください", type: "text"}
     .user-search-result
-    / この部分はインクリメンタルサーチ（ユーザー追加の非同期化のときに使用します
-    /
-      <div class='chat-group-form__field--left'>
-      <label class="chat-group-form__label" for="chat_group_チャットメンバーを追加">チャットメンバーを追加</label>
-      </div>
-      <div class='chat-group-form__field--right'>
-      <div class='chat-group-form__search clearfix'>
-      <input class='chat-group-form__input' id='user-search-field' placeholder='追加したいユーザー名を入力してください' type='text'>
-      </div>
-      <div id='user-search-result'></div>
-      </div>
 
-  .chat-group-form__field.clearfix
-    .chat-group-form__field--left
-      %label.chat-group-form__label{for: "chat_group_チャットメンバー"} チャットメンバー
-    .chat-group-form__field--right
-      / グループ作成機能の追加時はここにcollection_check_boxesの記述を入れてください
-      = f.collection_check_boxes(:user_ids, User.all, :id, :name) do |user|
-        = user.label { user.check_box + user.text }
   .chat-group-form__field.clearfix
     .chat-group-form__field--left
     .chat-group-form__field--right

--- a/app/views/users/index.json.jbuilder
+++ b/app/views/users/index.json.jbuilder
@@ -1,0 +1,4 @@
+json.array! @users do |user|
+  json.id user.id
+  json.name user.name
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   root to: 'groups#index'
 
-  resources :users, only: [:edit, :update]
+  resources :users, only: [:index, :edit, :update]
   resources :groups, only: [:new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
   end


### PR DESCRIPTION
# What
グループ画面でのユーザー検索をインクリメンタルサーチで検索できるようにする。

# Why
現在のcheckBoxを表示する方法では、検索性が低く使いにくいから。

# 実装ステップ
## インクリメンタルサーチ
1. ルーティングなどAPI側の準備をする
2. テキストフィールドを作成する
3. テキストフィールドに入力されるたびにイベントが発火するようにする
4. イベント時に非同期通信できるようにする
5. 非同期通信の結果を得て、HTMLを作成する
6. HTMLをビュー上に追加する
7. エラー時の処理を行う

## インクリメンタルサーチ表示後
1. 追加を押されたときにイベントを発火する
2. 検索結果からHTMLを消し、チャットメンバーの部分にHTMLを追加する
3. 削除を押すと、チャットメンバーから削除する