### PR TITLE
自動更新機能の実装

### DIFF
--- a/app/assets/javascripts/messages.js
+++ b/app/assets/javascripts/messages.js
@@ -68,10 +68,8 @@ $(function() {
     .done(function(message) {
       //HTML要素を作成して追加
       buildMessage(message);
-      //入力エリアクリア
-      $("#form--text-input").val("");
-      //画像ファイルクリア
-      $("#form--file-select-icon__display").val("");
+      //formリセット
+      $("#form")[0].reset();
       //最新メッセージにスクロール
       scroll_latest_message(1000)
       //Sendボタンの有効化

--- a/app/assets/javascripts/messages.js
+++ b/app/assets/javascripts/messages.js
@@ -1,4 +1,5 @@
 $(function() {
+
   // 個々のmessageを表示するHTMLを作成
   function buildMessage(message) {
     var html = null;
@@ -76,4 +77,26 @@ $(function() {
       send_button_enable();
     });
   });
+
+  //メッセージの自動更新
+  var reloadMessages = function() {
+    //カスタムデータ属性を利用し、ブラウザに表示されている最新メッセージのidを取得
+    last_message_id = $(".message").last().data("id")
+    $.ajax({
+      //ルーティングで設定した通りのURLを指定
+      url: location.pathname.substring(0,location.pathname.lastIndexOf('/')) + "/api/messages",
+      //ルーティングで設定した通りhttpメソッドをgetに指定
+      type: 'GET',
+      dataType: 'json',
+      //dataオプションでリクエストに値を含める
+      data: {last_message_id: last_message_id}
+    })
+    .done(function(messages) {
+      console.log('success');
+    })
+    .fail(function() {
+      console.log('error');
+    });
+  };
+  setInterval(reloadMessages, 5000);
 })

--- a/app/assets/javascripts/messages.js
+++ b/app/assets/javascripts/messages.js
@@ -109,7 +109,6 @@ $(function() {
       }
     })
     .fail(function() {
-      console.log('error');
     });
   };
   // 一定期間ごとにメッセージ更新を確認。turbolinksの影響で全てのページで発生するため、

--- a/app/assets/javascripts/messages.js
+++ b/app/assets/javascripts/messages.js
@@ -112,6 +112,11 @@ $(function() {
       console.log('error');
     });
   };
-  // 一定期間ごとにメッセージ更新を確認
-  setInterval(reloadMessages, 5000);
+  // 一定期間ごとにメッセージ更新を確認。turbolinksの影響で全てのページで発生するため、
+  // /groups/:id/messages となるパスでのみ実行できるようにする。
+  var pattern = /^\/groups\/\d+\/messages$/;
+  var reg = new RegExp(pattern);
+  if(reg.test(location.pathname)) {
+    setInterval(reloadMessages,5000)
+  }
 })

--- a/app/assets/javascripts/messages.js
+++ b/app/assets/javascripts/messages.js
@@ -20,7 +20,7 @@ $(function() {
       </div>`
     }
 
-    html = `<div class="message">
+    html = `<div class="message" data-id="${message.id}">
               <div class="message--title">
                 <span class="message--title__post-user">${message.user_name}</span>
                 <span class="message--title__post-date">${message.create_date}</span>
@@ -39,6 +39,18 @@ $(function() {
   //jqueryで無効化したSendボタンの有効化
   function send_button_enable() {
     $('#form--send-button').prop('disabled', false);
+  }
+
+  //最新メッセージにスクロール
+  function scroll_latest_message(time)
+  {
+    //現在位置+最終コメント要素の相対位置にスクロール
+    var currentScrollTop = $(".chat--messages").scrollTop()
+    var scrollSize = $(".message").last().offset().top
+    $(".chat--messages").animate(
+      { scrollTop: currentScrollTop + scrollSize },
+      { duration: time }
+    );
   }
 
   $(".new_message").on("submit", function(e) {
@@ -60,13 +72,8 @@ $(function() {
       $("#form--text-input").val("");
       //画像ファイルクリア
       $("#form--file-select-icon__display").val("");
-      //現在位置+最終コメント要素の相対位置にスクロール
-      var currentScrollTop = $(".chat--messages").scrollTop()
-      var scrollSize = $(".message").last().offset().top
-      $(".chat--messages").animate(
-        { scrollTop: currentScrollTop + scrollSize },
-        { duration: 2000 }
-      );
+      //最新メッセージにスクロール
+      scroll_latest_message(1000)
       //Sendボタンの有効化
       send_button_enable();
     })
@@ -92,11 +99,19 @@ $(function() {
       data: {last_message_id: last_message_id}
     })
     .done(function(messages) {
-      console.log('success');
+      if (messages.length !== 0) {
+        //配列messagesの中身一つ一つを取り出し、HTMLに変換したものをメッセージに追加する
+        messages.forEach(function(message) {
+          buildMessage(message);
+        });
+        //最新メッセージにスクロール
+        scroll_latest_message(1000)
+      }
     })
     .fail(function() {
       console.log('error');
     });
   };
+  // 一定期間ごとにメッセージ更新を確認
   setInterval(reloadMessages, 5000);
 })

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,0 +1,19 @@
+class Api::MessagesController < ApplicationController
+  def index
+
+    # 最新メッセージ以降で同じチャットグループのメッセージを取得
+    @messages = Message.where("id > ?", chat_param[:last_message_id])
+                  .where(group_id: chat_param[:group_id])
+
+    # jsonで返す
+    respond_to do |format|
+      format.json { }
+    end
+  end
+
+  private
+  def chat_param
+    params.permit(:last_message_id, :group_id)
+  end
+
+end

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,7 +1,7 @@
 json.array! @messages do |message|
   json.body message.body
   json.image message.image
-  json.created_at message.created_at.strftime("%Y/%m/%d(%a) %H:%M:%S")
+  json.create_date message.created_at.strftime("%Y/%m/%d(%a) %H:%M:%S")
   json.user_name message.user.name
   json.id message.id
 end

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,0 +1,7 @@
+json.array! @messages do |message|
+  json.body message.body
+  json.image message.image
+  json.created_at message.created_at.strftime("%Y/%m/%d(%a) %H:%M:%S")
+  json.user_name message.user.name
+  json.id message.id
+end

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,4 +1,4 @@
-.message
+.message{data: {id: message.id}}
   .message--title
     %span.message--title__post-user<>
       = message.user.name

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -2,3 +2,5 @@ json.body @message.body
 json.image @message.image
 json.user_name @message.user.name
 json.create_date @message.created_at.strftime("%Y/%m/%d(%a) %H:%M:%S")
+#idも渡す
+json.id = @message.id

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -3,4 +3,4 @@ json.image @message.image
 json.user_name @message.user.name
 json.create_date @message.created_at.strftime("%Y/%m/%d(%a) %H:%M:%S")
 #idも渡す
-json.id = @message.id
+json.id @message.id

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,5 +6,8 @@ Rails.application.routes.draw do
   resources :users, only: [:index, :edit, :update]
   resources :groups, only: [:new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
+    namespace :api do
+      resources :messages, only: :index, defaults: { format: "json" }
+    end
   end
 end


### PR DESCRIPTION
# What
チャット画面の自動更新機能を実装する
# Why
更新ボタンを押さないと最新メッセージが取得できず使用感が悪いため
# やること
1. 表示されているメッセージのHTMLにid情報を追加
2. メッセージを更新するためのアクションを実装
3. 追加したアクションを動かすためのルーティングを実装
4. 追加したアクションをリクエストするよう実装
5. 取得した最新のメッセージをブラウザのメッセージ一覧に追加
6. 数秒ごとにリクエストするよう実装
7. メッセージ分だけスクロールするよう実装
8. メッセージ一覧のページでのみJSが動くよう実装