### PR TITLE
Capistrano設定ミスの修正

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -5,8 +5,6 @@ require "capistrano/setup"
 require "capistrano/deploy"
 
 # Include tasks from other gems included in your Gemfile
-require "capistrano/setup"
-require "capistrano/deploy"
 require 'capistrano/rbenv'
 require 'capistrano/bundler'
 require 'capistrano/rails/assets'

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -7,7 +7,7 @@
 # server "example.com", user: "deploy", roles: %w{app web}, other_property: :other_value
 # server "db.example.com", user: "deploy", roles: %w{db}
 
-server 'http://3.114.75.25', user: 'ec2-user', roles: %w{app db web}
+server '3.114.75.25', user: 'ec2-user', roles: %w{app db web}
 
 # role-based syntax
 # ==================


### PR DESCRIPTION
# What
Capistranoのデプロイコマンド実行時に発生したエラーの修正。
原因はCapfileにrequireが重複して書かれていたことと、
production.rcのサーバーのアドレスにhttp:を付けて指定していた。

# Why
アプリケーションのバグによりデプロイが行えないから